### PR TITLE
react_loop.py 一处小bug的修复

### DIFF
--- a/core/react_loop.py
+++ b/core/react_loop.py
@@ -827,8 +827,9 @@ During each thought, naturally plan:
             preview_lines = content.split("\n")[:20]
             preview = "\n".join(preview_lines)
 
-            if len(content.split("\n")) > 20:
-                return f"📄 {path} ({lines} lines, {size} chars)\n```\n{preview}\n...\n```\n📋 Showing first 20 lines, full content saved ({len(content.split('\n'))} lines total)"
+            total_lines = len(content.split("\n"))
+            if total_lines > 20:
+                return f"📄 {path} ({lines} lines, {size} chars)\n```\n{preview}\n...\n```\n📋 Showing first 20 lines, full content saved ({total_lines} lines total)"
             else:
                 return f"📄 {path} ({lines} lines, {size} chars)\n```\n{preview}\n```"
 


### PR DESCRIPTION
可能是python版本较旧，在f字符串中的求值触发了异常：

  File "G:\tek\Python\Python310\lib\site-packages\aacode\core\react_loop.py", line 831
    return f"📄 {path} ({lines} lines, {size} chars)\n```\n{preview}\n...\n```\n📋 Showing first 20 lines, full content saved ({len(content.split('\n'))} lines total)"
                                                                                                                                                                     ^
SyntaxError: f-string expression part cannot include a backslash

这个将 len(content.split('\n') 分拆计算就解决了。

修复这个问题后，aacode命令行即可以正常打印help了。
